### PR TITLE
Archives shall record the date

### DIFF
--- a/draft-thomson-rswg-syntax-change.md
+++ b/draft-thomson-rswg-syntax-change.md
@@ -91,7 +91,8 @@ the canonical version of that RFC.
 ## Archival
 
 When the RFC XML of an RFC is updated, the updated document shall be archived in
-addition to the existing version.
+addition to the existing version.  Any archive shall record the date that a
+document was created or revised.
 
 This document does not specify how archives are maintained or how archived RFC
 XML might be located or identified.


### PR DESCRIPTION
This is what archives do, so it's almost redundant to say this, but it's a reasonable thing to say and worthwhile being clear.

Based on feedback from @becarpenter