### PR TITLE
Advice about publication format regeneration

### DIFF
--- a/draft-thomson-rswg-syntax-change.md
+++ b/draft-thomson-rswg-syntax-change.md
@@ -137,7 +137,7 @@ This document has no IANA actions.
 
 This document does not include specific guidance regarding the generation of
 publication formats from RFC XML source.  Decisions about how to maintain
-publication formats is not a matter governed by the policy in RFC 9280
+publication formats are not a matter governed by policy as specified in RFC 9280
 {{?RFC9280}}.  This section contains advice and considerations for the process
 of regeneration that came out of discussions of the policy changes in this
 document.

--- a/draft-thomson-rswg-syntax-change.md
+++ b/draft-thomson-rswg-syntax-change.md
@@ -142,31 +142,37 @@ publication formats are not a matter governed by policy as specified in RFC 9280
 of regeneration that came out of discussions of the policy changes in this
 document.
 
-Changes to the RFC XML for existing documents might result in changes to
-publication formats.  At the same time, the tools used to generate publication
-formats are under active maintenance.  Regeneration of publication formats will
-use updated tools, a goal supported by the policy changes in this document.
+Changes to the RFC XML for existing documents might result in changes to the
+documents rendered from that XML.  At the same time, the tools used to generate
+rendered documents are under active maintenance.  Having it be possible for
+rendered documents to replace existing publication formats is a goal supported
+by the policy changes in this document.
 
-
-This creates a risk that publications formats change in unexpected ways when
+This creates a risk that rendered documents change in unexpected ways when
 they are regenerated.  This risk of unintentional change can be managed by
 implementing validation processes:
 
-1. Tools can be continuously checked by regenerating publication formats for
-   existing RFCs and any change in the resulting output can be validated.  This
-   will ensure that changes in tooling are deliberate and understood.
+1. Tools can be continuously checked by producing rendered documents for
+   existing RFCs.  Any change in the rendered document can then be compared with
+   previous outputs and validated.  This will ensure that changes in tooling are
+   deliberate and understood.
 
-2. When a change to XML occurs, publication formats can be regenerated and any
+2. When a change to XML occurs, rendered documents can be regenerated and any
    change in the resulting output can be validated.
 
 Validation should be aided by automated tooling that is able to disregard
 inconsequential changes, like changes in timestamps and other annotations.
 Validation of tooling can be continuous, for which automation is essential.
 
-In both cases, the decision to make regenerated publication formats available is
-a decision that can be made on a case-by-case basis.  Making regenerated
-publication formats available more often could mean a greater risk that people
-seeking to read RFCs will obtain a copy that contains accidental errors.
+In both cases, the decision to make rendered documents available as the
+publication format for an RFC is a decision that can be made on a case-by-case
+basis.  Making rendered documents available more often could mean a greater risk
+that people seeking to read RFCs will obtain a copy that contains accidental
+errors.  Conversely, errors in publication formats might persist if they are not
+replaced as tool quality and reliability improves.
+
+Old copies of replaced publication formats could be retained to provide the
+ability to isolate changes and understand the evolution of documents.
 
 
 # Acknowledgments

--- a/draft-thomson-rswg-syntax-change.md
+++ b/draft-thomson-rswg-syntax-change.md
@@ -133,9 +133,45 @@ This document has no IANA actions.
 
 --- back
 
+# Advice on Regenerating Publication Formats
+
+This document does not include specific guidance regarding the generation of
+publication formats from RFC XML source.  Decisions about how to maintain
+publication formats is not a matter governed by the policy in RFC 9280
+{{?RFC9280}}.  This section contains advice and considerations for the process
+of regeneration that came out of discussions of the policy changes in this
+document.
+
+Changes to the RFC XML for existing documents might result in changes to
+publication formats.  At the same time, the tools used to generate publication
+formats are under active maintenance.  Regeneration of publication formats will
+use updated tools, a goal supported by the policy changes in this document.
+
+
+This creates a risk that publications formats change in unexpected ways when
+they are regenerated.  This risk of unintentional change can be managed by
+implementing validation processes:
+
+1. Tools can be continuously checked by regenerating publication formats for
+   existing RFCs and any change in the resulting output can be validated.  This
+   will ensure that changes in tooling are deliberate and understood.
+
+2. When a change to XML occurs, publication formats can be regenerated and any
+   change in the resulting output can be validated.
+
+Validation should be aided by automated tooling that is able to disregard
+inconsequential changes, like changes in timestamps and other annotations.
+Validation of tooling can be continuous, for which automation is essential.
+
+In both cases, the decision to make regenerated publication formats available is
+a decision that can be made on a case-by-case basis.  Making regenerated
+publication formats available more often could mean a greater risk that people
+seeking to read RFCs will obtain a copy that contains accidental errors.
+
+
 # Acknowledgments
 {:numbered="false"}
 
-Thanks to Paul Hoffman, John Levine, Pete Resnick, and Alexis Rossi for
-constructive discussions about how the evolution of the RFC XML format might be
-managed.
+Thanks to Paul Hoffman, Eliot Lear, John Levine, Pete Resnick, and Alexis Rossi
+for constructive discussions about how the evolution of the RFC XML format might
+be managed.

--- a/draft-thomson-rswg-syntax-change.md
+++ b/draft-thomson-rswg-syntax-change.md
@@ -144,31 +144,32 @@ document.
 
 Changes to the RFC XML for existing documents might result in changes to the
 documents rendered from that XML.  At the same time, the tools used to generate
-rendered documents are under active maintenance.  Having it be possible for
-rendered documents to replace existing publication formats is a goal supported
-by the policy changes in this document.
+renderings are under active maintenance.  Having it be possible for a fresh
+rendering to replace existing publication formats is a goal supported by the
+policy changes in this document.
 
-This creates a risk that rendered documents change in unexpected ways when
+This creates a risk that a rerendered documents change in unexpected ways when
 they are regenerated.  This risk of unintentional change can be managed by
 implementing validation processes:
 
-1. Tools can be continuously checked by producing rendered documents for
-   existing RFCs.  Any change in the rendered document can then be compared with
-   previous outputs and validated.  This will ensure that changes in tooling are
+1. Tools can be continuously checked by producing renderings for existing RFCs.
+   Any change in the rendered document can then be compared with previous
+   outputs and validated.  This will ensure that changes in tooling are
    deliberate and understood.
 
 2. When a change to XML occurs, rendered documents can be regenerated and any
-   change in the resulting output can be validated.
+   change in the rendering can be validated.
 
 Validation should be aided by automated tooling that is able to disregard
-inconsequential changes, like changes in timestamps and other annotations.
-Validation of tooling can be continuous, for which automation is essential.
+inconsequential changes in renderings, like changes in timestamps and other
+annotations.  Validation of tooling can be continuous, for which automation is
+essential.
 
-In both cases, the decision to make rendered documents available as the
-publication format for an RFC is a decision that can be made on a case-by-case
-basis.  Making rendered documents available more often could mean a greater risk
-that people seeking to read RFCs will obtain a copy that contains accidental
-errors.  Conversely, errors in publication formats might persist if they are not
+In both cases, the decision to make renderings available as the publication
+format for an RFC is a decision that can be made on a case-by-case basis.
+Making fresh renderings available more often could mean a greater risk that
+people seeking to read RFCs will obtain a copy that contains accidental errors.
+At the same time, errors in publication formats might persist if they are not
 replaced as tool quality and reliability improves.
 
 Old copies of replaced publication formats could be retained to provide the

--- a/draft-thomson-rswg-syntax-change.md
+++ b/draft-thomson-rswg-syntax-change.md
@@ -106,11 +106,13 @@ XML might be located or identified.
 
 ## Publication Formats
 
-Publication formats are produced from the RFC XML format.  As the RFC XML format
-of a document changes, publication formats can change, even if this might not
-result in observable differences.  Similarly, as production tools change,
-publication formats can be regenerated to ensure a consistent presentation
-across the series.
+Publication formats are produced from the RFC XML format.  As noted in {{Section
+10.2 of !RFC7990}}, "publication formats may be republished as needed".
+
+As the RFC XML format of a document changes, publication formats can change,
+even if this might not result in observable differences.  Similarly, as
+production tools change, publication formats can be regenerated to ensure a
+consistent presentation across the series.
 
 Publication formats -- or the contexts in which they are displayed -- can
 optionally provide additional details of the specific RFC XML version that they


### PR DESCRIPTION
The discussion at the interim highlighted that there were things we wanted to say about regeneration, but that we really didn't want to be prescriptive about it.  This attempts to balance the desire to stay out of it with the desire to not stay out of it.